### PR TITLE
Use tumbleweed as base image for worker

### DIFF
--- a/worker-x86_64/Dockerfile
+++ b/worker-x86_64/Dockerfile
@@ -1,11 +1,7 @@
-FROM opensuse:42.3
+FROM opensuse:tumbleweed
 LABEL maintainer Sergio Lindo Mansilla <slindomansilla@suse.com>
-LABEL version="2017-11-16"
+LABEL version="2017-12-11"
 
-# At the moment, the only reliable source repository to install openQA is its
-# devel project in OBS.
-RUN zypper ar -f obs://devel:openQA/openSUSE_Leap_42.3 devel-openQA
-RUN zypper ar -f obs://devel:openQA:Leap:42.3/openSUSE_Leap_42.3 devel-openQA-perl-modules
 RUN zypper --gpg-auto-import-keys ref
 RUN zypper --non-interactive in qemu-kvm
 RUN zypper --non-interactive in openQA-worker


### PR DESCRIPTION
ATM the build process of the image base on tumbleweed fails:

```
Step 7/12 : RUN zypper --non-interactive in openQA-worker
 ---> Running in 7eaf04f0089c
Loading repository data...
Reading installed packages...
Resolving package dependencies...

Problem: nothing provides libopencv_core.so.3.2()(64bit) needed by os-autoinst-4.4.1511284591.d1020b93-470.1.x86_64
 Solution 1: do not install openQA-worker-4.5.1511290893.c1143c32-24.1.noarch
 Solution 2: break os-autoinst-4.4.1511284591.d1020b93-470.1.x86_64 by ignoring some of its dependencies

Choose from above solutions by number or cancel [1/2/c] (c): c
The command '/bin/sh -c zypper --non-interactive in openQA-worker' returned a non-zero code: 4
```