### PR TITLE
Remove patch for missing /var/lib/openqa/share #21

### DIFF
--- a/worker-x86_64/Dockerfile
+++ b/worker-x86_64/Dockerfile
@@ -1,13 +1,12 @@
 FROM opensuse:tumbleweed
 LABEL maintainer Sergio Lindo Mansilla <slindomansilla@suse.com>
-LABEL version="2017-12-11"
+LABEL version="2018-06-15"
 
 RUN zypper --gpg-auto-import-keys ref
 RUN zypper --non-interactive in qemu-kvm
 RUN zypper --non-interactive in openQA-worker
 
 # Config
-RUN mkdir /var/lib/openqa/share
 ADD client.conf /etc/openqa/
 ADD workers.ini /etc/openqa/
 


### PR DESCRIPTION
See https://github.com/binary-sequence-dockerized-apps/dockerized-openQA/issues/21